### PR TITLE
Fail fast on invalid session metadata

### DIFF
--- a/tests/test_build_presets_failfast.py
+++ b/tests/test_build_presets_failfast.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+import unittest
+
+import pandas as pd
+
+from scripts.build_presets_all import build_presets_all
+
+
+class TestBuildPresetsFailFast(unittest.TestCase):
+    def test_raises_when_session_summary_corrupt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            pre_path = base / "precomputed.csv"
+            snapshot_path = base / "snapshot.csv"
+            session_summary_path = base / "session_summary.csv"
+            out_path = base / "presets.csv"
+
+            pd.DataFrame(
+                [
+                    {
+                        "Ticker": "AAA",
+                        "MA10": 10.0,
+                        "MA20": 11.0,
+                        "MA50": 12.0,
+                        "BB20Upper": 13.0,
+                        "BB20Lower": 9.0,
+                        "ATR14": 1.5,
+                    }
+                ]
+            ).to_csv(pre_path, index=False)
+
+            pd.DataFrame(
+                [
+                    {
+                        "Ticker": "AAA",
+                        "Price": 15.0,
+                    }
+                ]
+            ).to_csv(snapshot_path, index=False)
+
+            session_summary_path.write_text("", encoding="utf-8")
+
+            with self.assertRaises(pd.errors.EmptyDataError):
+                build_presets_all(
+                    precomputed_path=str(pre_path),
+                    snapshot_path=str(snapshot_path),
+                    out_path=str(out_path),
+                    session_summary_path=str(session_summary_path),
+                    daily_band_pct=0.1,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_order_engine_market_regime_failfast.py
+++ b/tests/test_order_engine_market_regime_failfast.py
@@ -1,0 +1,34 @@
+import unittest
+
+import pandas as pd
+
+from scripts.order_engine import get_market_regime
+
+
+class TestMarketRegimeFailFast(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sector_strength = pd.DataFrame()
+        self.tuning = {}
+
+    def test_empty_session_summary_raises(self):
+        session_summary = pd.DataFrame(columns=["SessionPhase", "InVNSession", "IndexChangePct"])
+        with self.assertRaisesRegex(ValueError, "session_summary is empty"):
+            get_market_regime(session_summary, self.sector_strength, self.tuning)
+
+    def test_missing_required_columns_raises(self):
+        session_summary = pd.DataFrame([
+            {"SessionPhase": "morning", "IndexChangePct": 0.1}
+        ])
+        with self.assertRaisesRegex(KeyError, "InVNSession"):
+            get_market_regime(session_summary, self.sector_strength, self.tuning)
+
+    def test_non_numeric_index_change_pct_raises(self):
+        session_summary = pd.DataFrame([
+            {"SessionPhase": "morning", "InVNSession": 1, "IndexChangePct": "not-a-number"}
+        ])
+        with self.assertRaisesRegex(ValueError, "IndexChangePct"):
+            get_market_regime(session_summary, self.sector_strength, self.tuning)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- propagate session_summary.csv read errors in build_presets_all so corrupt files stop the run
- have the pipeline reuse _infer_in_session for session detection to surface invalid metadata immediately
- add a regression test ensuring a malformed session summary halts preset generation
- raise explicit errors in get_market_regime when session_summary data are missing or invalid so the order engine cannot silently default to pre-market
- add dedicated fail-fast tests covering the order engine session requirements

## Testing
- ./broker.sh tests

------
https://chatgpt.com/codex/tasks/task_e_68e22feab5fc832a9e019ec7fbab66b3